### PR TITLE
Fix the cross-branch link to the Kitesurf evidence index

### DIFF
--- a/docs/EVIDENCE.md
+++ b/docs/EVIDENCE.md
@@ -50,7 +50,7 @@ individual failure rather than only the result row.
 | `artifacts-resource_engine_20260812.tar.gz` | 70,505 files | 13.1 MiB | 171 MiB |
 
 The Kitesurf lane ships two more assets on the same release, indexed by
-[`docs/EVIDENCE.md` on the `kitesurf-eval` branch](../../tree/kitesurf-eval/docs/EVIDENCE.md).
+[`docs/EVIDENCE.md` on the `kitesurf-eval` branch](../../../tree/kitesurf-eval/docs/EVIDENCE.md).
 
 ### sha256
 

--- a/docs/EVIDENCE.zh.md
+++ b/docs/EVIDENCE.zh.md
@@ -45,7 +45,7 @@
 | `artifacts-resource_engine_20260812.tar.gz` | 70,505 个文件 | 13.1 MiB | 171 MiB |
 
 Kitesurf lane 另有两个资产挂在同一个 Release 上，由
-[`kitesurf-eval` 分支的 `docs/EVIDENCE.md`](../../tree/kitesurf-eval/docs/EVIDENCE.md)
+[`kitesurf-eval` 分支的 `docs/EVIDENCE.md`](../../../tree/kitesurf-eval/docs/EVIDENCE.md)
 索引。
 
 ### sha256


### PR DESCRIPTION
`docs/EVIDENCE.md` and its Chinese counterpart linked the Kitesurf lane's index as `../../tree/kitesurf-eval/docs/EVIDENCE.md`. Resolved against a blob URL one directory deep, that lands on `/blob/tree/kitesurf-eval/...` and 404s; the root-level README uses the same form correctly because it sits one level higher.

Both links now use `../../../`, which resolves to `https://github.com/lexmount/Lexbench-Headless-Browser/tree/kitesurf-eval/docs/EVIDENCE.md`.