### PR TITLE
Name the evidence release by when its runs were collected

### DIFF
--- a/docs/EVIDENCE.md
+++ b/docs/EVIDENCE.md
@@ -38,6 +38,7 @@ Attached to [evidence-20260812](https://github.com/lexmount/Lexbench-Headless-Br
 a tag that names when the runs were collected rather than the state of the
 code: the runs date from 2026-08-12 and 2026-08-13, while the tree the tag
 points at is later than that.
+
 Each `evidence-*` archive holds one run's `results.jsonl`,
 `host_telemetry.jsonl` and `scorecard.md`; each `artifacts-*` archive holds
 that run's per-attempt protocol logs, which is what lets a third party audit an

--- a/docs/EVIDENCE.md
+++ b/docs/EVIDENCE.md
@@ -34,7 +34,10 @@ below.
 
 ## Release assets
 
-Attached to [v0.5.0](https://github.com/lexmount/Lexbench-Headless-Browser/releases/tag/v0.5.0).
+Attached to [evidence-20260812](https://github.com/lexmount/Lexbench-Headless-Browser/releases/tag/evidence-20260812),
+a tag that names when the runs were collected rather than the state of the
+code: the runs date from 2026-08-12 and 2026-08-13, while the tree the tag
+points at is later than that.
 Each `evidence-*` archive holds one run's `results.jsonl`,
 `host_telemetry.jsonl` and `scorecard.md`; each `artifacts-*` archive holds
 that run's per-attempt protocol logs, which is what lets a third party audit an

--- a/docs/EVIDENCE.zh.md
+++ b/docs/EVIDENCE.zh.md
@@ -30,8 +30,11 @@
 
 ## Release 资产
 
-挂在 [v0.5.0](https://github.com/lexmount/Lexbench-Headless-Browser/releases/tag/v0.5.0)
-上。每个 `evidence-*` 包含一次 run 的 `results.jsonl`、`host_telemetry.jsonl` 和
+挂在 [evidence-20260812](https://github.com/lexmount/Lexbench-Headless-Browser/releases/tag/evidence-20260812)
+上。这个 tag 命名的是采集时间而不是代码状态：这批 run 采集于 2026-08-12 和 08-13，
+而 tag 指向的那棵树比它们更晚。
+
+每个 `evidence-*` 包含一次 run 的 `results.jsonl`、`host_telemetry.jsonl` 和
 `scorecard.md`；每个 `artifacts-*` 包含该次 run 每个 attempt 的原始协议日志，第三方
 因此可以审计某一次失败的协议交互，而不只是看结果行。
 


### PR DESCRIPTION
The release carrying the full run logs is now tagged `evidence-20260812` instead of `v0.5.0`, and the two index pages point at it.

`v0.5.0` said something about the code; this release is a data drop, so the tag now says which runs are inside. The package version stays `0.5.0` in `pyproject.toml` and `package.json`, where it belongs.

Both index pages also gained one clause that the old name did not need: the runs were collected on 2026-08-12 and 08-13, while the tree this tag points at is later, so a reader does not mistake the tag for a claim about the state of the code.

Release: https://github.com/lexmount/Lexbench-Headless-Browser/releases/tag/evidence-20260812 — all eight assets survived the retag, and their sha256 still match the index unchanged.