### PR TITLE
Say task subsets instead of calibers in the README and deployment docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 <p align="center"><strong>The next user of the headless browser is the agent.</strong></p>
 
-You are on `kitesurf-eval`, the evaluation lane for [Kitesurf](https://blog.cloudflare.com/kitesurf/), the agent-first cloud browser Cloudflare just launched. The [`main`](https://github.com/lexmount/Lexbench-Headless-Browser) branch carries the full story: the benchmark's motivation, the four-engine leaderboard over locally pinned binaries, and the resource measurements. Kitesurf exists only behind a remote endpoint, with no binary digest and no process tree to measure, so its evidence class differs from a local binary (`formal_score_eligible: false`). This branch adds the fifth column, the machinery that makes a remote engine measurable at all, and reports the comparison under two explicit calibers. Everything else, the 1,928-task set, the drivers, the graders and the methodology, is identical to `main`.
+You are on `kitesurf-eval`, the evaluation lane for [Kitesurf](https://blog.cloudflare.com/kitesurf/), the agent-first cloud browser Cloudflare just launched. The [`main`](https://github.com/lexmount/Lexbench-Headless-Browser) branch carries the full story: the benchmark's motivation, the four-engine leaderboard over locally pinned binaries, and the resource measurements. Kitesurf exists only behind a remote endpoint, with no binary digest and no process tree to measure, so its evidence class differs from a local binary (`formal_score_eligible: false`). This branch adds the fifth column, the machinery that makes a remote engine measurable at all, and reports the comparison on two explicitly defined task subsets. Everything else, the 1,928-task set, the drivers, the graders and the methodology, is identical to `main`.
 
 ## Results
 
@@ -28,7 +28,7 @@ You are on `kitesurf-eval`, the evaluation lane for [Kitesurf](https://blog.clou
 
 <div align="center">
 
-| Engine | Caliber A (1,671 tasks) | Caliber B (1,308 tasks) |
+| Engine | Task subset A (1,671 tasks) | Task subset B (1,308 tasks) |
 |:---|---:|---:|
 | [Chrome for Testing](https://googlechromelabs.github.io/chrome-for-testing/) | 1,669 / 1,671 · **99.88%** | 1,306 / 1,308 · **99.85%** |
 | [Moli](https://github.com/lexmount/moli) | 1,359 / 1,671 · **81.33%** | 1,071 / 1,308 · **81.88%** |
@@ -38,9 +38,9 @@ You are on `kitesurf-eval`, the evaluation lane for [Kitesurf](https://blog.clou
 
 </div>
 
-Both calibers start from the same 1,928-task corpus and drop tasks for all five engines alike. Caliber A removes 257 tasks in three subsets where a remote endpoint makes failures unattributable, leaving the attributable surface. Caliber B removes a further 363 tasks in four subsets that come back as whole-column zeroes with a single systematic root cause each, leaving the set where the five columns are directly comparable. The Kitesurf lane runs at k=1 with B-class adjudication and covered 1,305 caliber-A and 1,302 caliber-B tasks; whatever it did not cover counts as not passed. Full report: [docs/reports/five-engine-report-20260813.md](docs/reports/five-engine-report-20260813.md).
+Both task subsets start from the same 1,928-task corpus and drop tasks for all five engines alike. Task subset A removes 257 tasks in three subsets where a remote endpoint makes failures unattributable, leaving the attributable surface. Task subset B removes a further 363 tasks in four subsets that come back as whole-column zeroes with a single systematic root cause each, leaving the set where the five columns are directly comparable. The Kitesurf lane runs at k=1 with B-class adjudication and covered 1,305 tasks of subset A and 1,302 of subset B; whatever it did not cover counts as not passed. Full report: [docs/reports/five-engine-report-20260813.md](docs/reports/five-engine-report-20260813.md) (the report labels the two task subsets Caliber A and Caliber B).
 
-The four-engine leaderboard over the full corpus, where every engine is a pinned local binary and no caliber is needed, is on [`main`](https://github.com/lexmount/Lexbench-Headless-Browser#results).
+The four-engine leaderboard over the full corpus, where every engine is a pinned local binary and nothing needs to be dropped, is on [`main`](https://github.com/lexmount/Lexbench-Headless-Browser#results).
 
 ## Resource Cost
 
@@ -63,7 +63,7 @@ Median peak process-tree memory per task: Lightpanda 34 MiB, Obscura 39 MiB, Mol
 | [docs/EVIDENCE.md](docs/EVIDENCE.md) | The evidence chain: run fingerprints, release archives, and the commands that regenerate the reports |
 | [docs/RUNNING.md](docs/RUNNING.md) | Installing the engines and drivers, and running the bench |
 | [docs/REPRODUCE.md](docs/REPRODUCE.md) | Reproducing the published runs and regenerating their reports |
-| [docs/RESULTS.md](docs/RESULTS.md) | Reading the results: scoring boundaries, calibers and limits |
+| [docs/RESULTS.md](docs/RESULTS.md) | Reading the results: scoring boundaries and limits |
 | [docs/reports/](docs/reports/) | The reports themselves, generated from run artifacts |
 
 ## What this branch adds
@@ -71,7 +71,7 @@ Median peak process-tree memory per task: Lightpanda 34 MiB, Obscura 39 MiB, Mol
 - The generic `remote_cdp` identity contract in the runner and the adapters, with three-field same-connection verification, so a remote endpoint passes the same anti-substitution gate a local binary does. See [runner/scripts/adapters/PROTOCOL.md](runner/scripts/adapters/PROTOCOL.md).
 - The recipe machinery: `tools/kitesurf_experiments.py {check,list,render,run}` over [config/kitesurf_experiments.json](config/kitesurf_experiments.json).
 - A two-origin fixture contract: static fixtures served from this repository's GitHub Pages (`pages/`, pinned by [config/kitesurf_static_fixture.json](config/kitesurf_static_fixture.json)) and a self-deployed dynamic origin (`python3 -m runner.run fixture-serve` behind an HTTPS tunnel, contract-verified by [config/kitesurf_dynamic_fixture.json](config/kitesurf_dynamic_fixture.json)).
-- Five-engine aggregation: `tools/report_five_engine.py` computes the published denominators, the caliber split and the B-class adjudication instead of narrating them.
+- Five-engine aggregation: `tools/report_five_engine.py` computes the published denominators, the task-subset split and the B-class adjudication instead of narrating them.
 
 Start with [docs/kitesurf-deployment.md](docs/kitesurf-deployment.md) for the fixture resolution rules and the four-command flow. Once Kitesurf ships a local binary it joins the main roster and this branch retires.
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -15,7 +15,7 @@
 
 <p align="center"><strong>无头浏览器的下一个使用者是 Agent。</strong></p>
 
-你现在在 `kitesurf-eval`，也就是 [Kitesurf](https://blog.cloudflare.com/kitesurf/)——Cloudflare 新发布的 agent-first 云端浏览器——的评测分支。完整的项目介绍与动机在 [`main`](https://github.com/lexmount/Lexbench-Headless-Browser/blob/main/README.zh.md) 分支：这个 benchmark 为什么存在、四个本地固定二进制引擎的排行榜，以及资源测量。Kitesurf 目前只以远程端点的形态存在，没有二进制摘要，也没有可测量的进程树，证据等级与本地二进制不同（`formal_score_eligible: false`）。这个分支加上第五列、让远程引擎变得可测的那套机制，并在两个明确的口径下发布对比结果。其余一切——1,928 道任务集、driver、grader 和方法——与 `main` 完全一致。
+你现在在 `kitesurf-eval`，也就是 Cloudflare 新发布的 agent-first 云端浏览器 [Kitesurf](https://blog.cloudflare.com/kitesurf/) 的评测分支。完整的项目介绍与动机在 [`main`](https://github.com/lexmount/Lexbench-Headless-Browser/blob/main/README.zh.md) 分支：这个 benchmark 为什么存在、四个本地固定二进制引擎的排行榜，以及资源测量。Kitesurf 目前只以远程端点的形态存在，没有二进制摘要，也没有可测量的进程树，证据等级与本地二进制不同（`formal_score_eligible: false`）。这个分支加上第五列、让远程引擎变得可测的那套机制，并在两个明确定义的任务子集上发布对比结果。其余一切（1,928 道任务集、driver、grader 和方法）与 `main` 完全一致。
 
 ## Results
 
@@ -28,7 +28,7 @@
 
 <div align="center">
 
-| 引擎 | 口径 A（1,671 道） | 口径 B（1,308 道） |
+| 引擎 | 任务子集 A（1,671 道） | 任务子集 B（1,308 道） |
 |:---|---:|---:|
 | [Chrome for Testing](https://googlechromelabs.github.io/chrome-for-testing/) | 1,669 / 1,671 · **99.88%** | 1,306 / 1,308 · **99.85%** |
 | [Moli](https://github.com/lexmount/moli) | 1,359 / 1,671 · **81.33%** | 1,071 / 1,308 · **81.88%** |
@@ -38,9 +38,9 @@
 
 </div>
 
-两个口径都从同一份 1,928 道的任务集出发，剔除的题对五个引擎一视同仁。口径 A 去掉三个 subset 共 257 道题，因为面对远程端点时失败无法归因，剩下的就是可归因面。口径 B 在此基础上再去掉四个 subset 共 363 道题，它们整列为零且各自有单一的系统性根因，剩下的就是五列可以直接对比的集合。Kitesurf 这条 lane 以 k=1 加 B 类裁定运行，覆盖了 1,305 道口径 A 题和 1,302 道口径 B 题，未覆盖的一律按未通过计。完整报告见 [docs/reports/five-engine-report-20260813.md](docs/reports/five-engine-report-20260813.md)。
+两个任务子集都从同一份 1,928 道的任务集出发，剔除的题对五个引擎一视同仁。任务子集 A 去掉三个 subset 共 257 道题，因为面对远程端点时失败无法归因，剩下的就是可归因面。任务子集 B 在此基础上再去掉四个 subset 共 363 道题，它们整列为零且各自有单一的系统性根因，剩下的就是五列可以直接对比的集合。Kitesurf 这条 lane 以 k=1 加 B 类裁定运行，覆盖了任务子集 A 里的 1,305 道和任务子集 B 里的 1,302 道，未覆盖的一律按未通过计。完整报告见 [docs/reports/five-engine-report-20260813.md](docs/reports/five-engine-report-20260813.md)（报告中两个任务子集记作 Caliber A/B）。
 
-全任务集上的四引擎排行榜——每个引擎都是本地固定二进制、不需要任何口径的那份——在 [`main`](https://github.com/lexmount/Lexbench-Headless-Browser/blob/main/README.zh.md#results)。
+全任务集上的四引擎排行榜（每个引擎都是本地固定二进制、不需要任何剔除的那份）在 [`main`](https://github.com/lexmount/Lexbench-Headless-Browser/blob/main/README.zh.md#results)。
 
 ## Resource Cost
 
@@ -63,7 +63,7 @@
 | [docs/EVIDENCE.zh.md](docs/EVIDENCE.zh.md) | 证据链：run 的指纹文件、Release 压缩包，以及重新生成报告的命令 |
 | [docs/RUNNING.zh.md](docs/RUNNING.zh.md) | 怎么装引擎和 driver，怎么把 bench 跑起来 |
 | [docs/REPRODUCE.zh.md](docs/REPRODUCE.zh.md) | 怎么复现已发布的 run，怎么重新生成报告 |
-| [docs/RESULTS.zh.md](docs/RESULTS.zh.md) | 结果怎么读：判定边界、口径与适用范围 |
+| [docs/RESULTS.zh.md](docs/RESULTS.zh.md) | 结果怎么读：判定边界与适用范围 |
 | [docs/reports/](docs/reports/) | 报告本身，由 run 产物生成 |
 
 ## 这个分支多了什么
@@ -71,7 +71,7 @@
 - runner 和各 adapter 里通用的 `remote_cdp` 身份契约，采用同一连接上的三字段校验，让远程端点也要过和本地二进制一样的防偷换关卡。见 [runner/scripts/adapters/PROTOCOL.md](runner/scripts/adapters/PROTOCOL.md)。
 - 配方机制：`tools/kitesurf_experiments.py {check,list,render,run}`，作用于 [config/kitesurf_experiments.json](config/kitesurf_experiments.json)。
 - 双 origin 的 fixture 契约：静态 fixture 由本仓库的 GitHub Pages 提供（`pages/`，由 [config/kitesurf_static_fixture.json](config/kitesurf_static_fixture.json) 固定），动态 origin 则自行部署（`python3 -m runner.run fixture-serve` 加一条 HTTPS 隧道，由 [config/kitesurf_dynamic_fixture.json](config/kitesurf_dynamic_fixture.json) 做契约校验）。
-- 五引擎聚合：`tools/report_five_engine.py` 直接计算已发布的分母、口径划分和 B 类裁定，而不是用文字描述它们。
+- 五引擎聚合：`tools/report_five_engine.py` 直接计算已发布的分母、任务子集划分和 B 类裁定，而不是用文字描述它们。
 
 先读 [docs/kitesurf-deployment.zh.md](docs/kitesurf-deployment.zh.md)，里面是 fixture 的解析规则和四条命令的流程。等 Kitesurf 提供本地二进制，它就并入主名单，这个分支随之退役。
 

--- a/docs/kitesurf-deployment.md
+++ b/docs/kitesurf-deployment.md
@@ -56,7 +56,7 @@ python3 tools/kitesurf_experiments.py run raw_full \
 
 ## Boundary declarations
 
-- **Latency budget.** Task timeouts are set to the same caliber as the local engines (30s for most
+- **Latency budget.** Task timeouts are the same as for the local engines (30s for most
   tasks). Your entire path (local machine →
   tunnel → remote endpoint → tunnel → local machine) counts against the budget. A high-latency path
   will push borderline tasks into

--- a/docs/kitesurf-deployment.zh.md
+++ b/docs/kitesurf-deployment.zh.md
@@ -48,7 +48,7 @@ python3 tools/kitesurf_experiments.py run raw_full \
 
 ## 边界声明
 
-- **延迟预算。**任务超时按本地引擎口径设定（多数 30s）。你的链路（本机 →
+- **延迟预算。**任务超时与本地引擎用同一套标准（多数 30s）。你的链路（本机 →
   隧道 → 远程端点 → 隧道 → 本机）全程计入。高延迟链路会把边缘任务推成
   timeout——这是部署属性，不是引擎属性；报告结论前先看
   `runs/<id>/results.jsonl` 里 timeout 的分布。


### PR DESCRIPTION
Renames the caliber wording to "task subsets" in both READMEs and both deployment docs, matching the terminology settled on `main` (#6).

- Results table headers become **Task subset A (1,671 tasks)** / **Task subset B (1,308 tasks)**; the definition paragraph is rewritten in the same terms.
- One parenthetical after the report link notes that the generated report still labels the two subsets Caliber A/B; it stays until `tools/report_five_engine.py` is revised and the report regenerated, so the byte-identical regeneration property is untouched.
- The deployment docs drop the same word from the latency-budget line.
- Dash asides in the touched sentences were reworked to the agreed style.

Prose-level "caliber" is now gone from this branch's README and deployment docs; the chart filename `five-engine-caliber-b-*.png` and the report itself are intentionally unchanged.