### PR TITLE
Move the five-engine glance ahead of the run parameters and center every table

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   </picture>
 </p>
 
-<p align="center"><b>1,928 tasks · <a href="#benchmark-composition">13 browser automation tools including Playwright, Puppeteer and Selenium</a> · 5 language ecosystems</b></p>
+<p align="center"><b>1,928 tasks · <a href="#benchmark-composition">13 browser automation tools including Playwright, Puppeteer and Selenium</a></b></p>
 
 Agents are taking over the web chores that used to be done by hand: searching, comparing prices, filling forms, placing orders. The page is no longer rendered for a person to look at: the agent reads state, performs operations and collects results inside it, and the browser has become the agent's runtime.
 
@@ -54,11 +54,6 @@ Lexbench-Headless-Browser turns that premise into something testable: every task
 
 </div>
 
-Run parameters: run id `four_engine_full_20260812`, bench tag `2026.08.02-v0_4.1`, seed `official20260709`, k=3, 23,136 result rows. A task counts as passed only when all three attempts pass. Each engine is scored on its own attempts (`--score-mode independent`); Chrome is the reference column. Full report: [docs/reports/four-engine-report-20260812.md](docs/reports/four-engine-report-20260812.md).
-
-> [!NOTE]
-> If you care about [Kitesurf](https://blog.cloudflare.com/kitesurf/), the agent-first cloud browser Cloudflare just launched, its evaluation lives on the [`kitesurf-eval`](https://github.com/lexmount/Lexbench-Headless-Browser/blob/kitesurf-eval/README.md) branch. Kitesurf currently exists only as a remote endpoint, with no binary digest and no resource measurement, so its evidence class differs from a locally pinned binary (`formal_score_eligible: false`) and the five-engine results are published on that branch.
-
 <details>
 <summary><b>Five-engine results at a glance (with Kitesurf, on a 1,308-task comparable subset)</b></summary>
 
@@ -69,6 +64,8 @@ Run parameters: run id `four_engine_full_20260812`, bench tag `2026.08.02-v0_4.1
   </picture>
 </div>
 
+<div align="center">
+
 | Engine | Comparable subset (1,308 tasks) |
 |:---|---:|
 | [Chrome for Testing](https://googlechromelabs.github.io/chrome-for-testing/) | 1,306 / 1,308 · **99.85%** |
@@ -77,9 +74,16 @@ Run parameters: run id `four_engine_full_20260812`, bench tag `2026.08.02-v0_4.1
 | [Lightpanda](https://github.com/lightpanda-io/browser) | 697 / 1,308 · **53.29%** |
 | [Obscura](https://github.com/h4ckf0r0day/obscura) | 587 / 1,308 · **44.88%** |
 
+</div>
+
 This comparison uses a subset of the same 1,928-task set: tasks whose failures cannot be attributed when the engine is a remote endpoint are removed, and the removal applies to all five engines alike; removing a task does not mean Kitesurf would pass it once a local binary ships. The subset definition and the full report are on the [`kitesurf-eval` branch](https://github.com/lexmount/Lexbench-Headless-Browser/blob/kitesurf-eval/README.md).
 
 </details>
+
+Run parameters: run id `four_engine_full_20260812`, bench tag `2026.08.02-v0_4.1`, seed `official20260709`, k=3, 23,136 result rows. A task counts as passed only when all three attempts pass. Each engine is scored on its own attempts (`--score-mode independent`); Chrome is the reference column. Full report: [docs/reports/four-engine-report-20260812.md](docs/reports/four-engine-report-20260812.md).
+
+> [!NOTE]
+> If you care about [Kitesurf](https://blog.cloudflare.com/kitesurf/), the agent-first cloud browser Cloudflare just launched, its evaluation lives on the [`kitesurf-eval`](https://github.com/lexmount/Lexbench-Headless-Browser/blob/kitesurf-eval/README.md) branch. Kitesurf currently exists only as a remote endpoint, with no binary digest and no resource measurement, and the five-engine results are published on that branch.
 
 ## Resource Cost
 
@@ -98,12 +102,16 @@ Median peak process-tree memory per task: Lightpanda 34 MiB, Obscura 39 MiB, Mol
 
 ## Documentation
 
+<div align="center">
+
 | Document | What it answers |
 |:---|:---|
 | [docs/RUNNING.md](docs/RUNNING.md) | Installing the engines and drivers, and running the bench |
 | [docs/REPRODUCE.md](docs/REPRODUCE.md) | Reproducing the published runs and regenerating their reports |
 | [docs/RESULTS.md](docs/RESULTS.md) | Reading the results: scoring boundaries and limits |
 | [docs/reports/](docs/reports/) | The reports themselves, generated from run artifacts |
+
+</div>
 
 ## Benchmark Composition
 
@@ -113,6 +121,8 @@ Current bench version `2026.08.17-v0_4.2`: 1,928 tasks in 18 subsets, on two lay
 - L2 measures web-platform semantics (188 tasks, 182 of which form the `l2.web_platform` subset). It covers DOM, storage, network, workers and CSSOM, and judges by what the page finally does rather than by protocol echo: a call that returns success while nothing happens on the page does not pass. The rows fold through a capability map into 72 capabilities; capabilities with semantic probes are scored per attempt (k=3), giving the 192 scoring units in the report's L2 row.
 
 The 13 drivers span five language ecosystems. Every version is pinned in [`harness_pins.json`](harness_pins.json) and verified by `doctor` before each run:
+
+<div align="center">
 
 | Driver | Ecosystem | Control path | Pinned version |
 |:---|:---|:---|:---|
@@ -130,6 +140,8 @@ The 13 drivers span five language ecosystems. Every version is pinned in [`harne
 | [chrome-devtools-mcp](https://github.com/ChromeDevTools/chrome-devtools-mcp) | Node | MCP → Puppeteer → CDP | 1.6.0 |
 | [agent-browser](https://github.com/vercel-labs/agent-browser) | Node | CLI session → CDP | 0.31.1 |
 
+</div>
+
 The task set is fixed by `manifest.json`: task content is frozen inside a bench version, and any change requires a version bump. The set will keep growing as engines and the driver ecosystem evolve, with new subsets and tasks shipped under new bench versions.
 
 ## Methodology
@@ -146,6 +158,8 @@ Functional and resource rounds never share a run. Resource figures come from the
 
 ## Repository Layout
 
+<div align="center">
+
 | Path | Contents |
 |:---|:---|
 | [`runner/`](runner/) | The harness: `run.py` (orchestration), `resources.py`, `bindings.py`, `scenario.py`, and the 13 driver adapters under `scripts/adapters/` |
@@ -157,6 +171,8 @@ Functional and resource rounds never share a run. Resource figures come from the
 | [`harness_pins.json`](harness_pins.json) | Pinned driver versions per ecosystem |
 | [`test/`](test/) | Harness unit tests (stdlib + pytest, no engine binaries needed) |
 | [`docs/`](docs/) | How to run, how to reproduce, how to read the results, and the reports |
+
+</div>
 
 ## License
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -22,7 +22,7 @@
   </picture>
 </p>
 
-<p align="center"><b>1,928 道 task · <a href="#benchmark-composition">Playwright、Puppeteer、Selenium 等 13 个浏览器自动化工具</a> · 5 个语言生态</b></p>
+<p align="center"><b>1,928 道 task · <a href="#benchmark-composition">Playwright、Puppeteer、Selenium 等 13 个浏览器自动化工具</a></b></p>
 
 Agent 正在接管搜索、比价、填表、下单这些原本由人完成的网页操作。页面不再渲染给人看：Agent 在里面读状态、执行操作、取回结果，浏览器成了 Agent 的运行时。
 
@@ -54,11 +54,6 @@ Lexbench-Headless-Browser 把这个前提变成可以测的东西：每道 task 
 
 </div>
 
-本次 run 的参数：run id `four_engine_full_20260812`，bench tag `2026.08.02-v0_4.1`，seed `official20260709`，k=3，共 23,136 条结果行。一道题三次 attempt 全部通过才算通过。每个引擎只按自己的 attempt 计分（`--score-mode independent`），Chrome 是参照列。完整报告见 [docs](docs/reports/four-engine-report-20260812.md)。
-
-> [!NOTE]
-> 如果你关心 Cloudflare 新发布的 agent-first 云端浏览器 [Kitesurf](https://blog.cloudflare.com/kitesurf/)，它的评测在 [`kitesurf-eval`](https://github.com/lexmount/Lexbench-Headless-Browser/blob/kitesurf-eval/README.zh.md) 分支。Kitesurf 目前只以远程端点形态存在，没有二进制摘要、无法测量资源，五引擎结果在该分支发布。
-
 <details>
 <summary><b>五引擎结果速览（含 Kitesurf，1,308 道可比任务子集）</b></summary>
 
@@ -69,6 +64,8 @@ Lexbench-Headless-Browser 把这个前提变成可以测的东西：每道 task 
   </picture>
 </div>
 
+<div align="center">
+
 | 引擎 | 可比子集（1,308 道） |
 |:---|---:|
 | [Chrome for Testing](https://googlechromelabs.github.io/chrome-for-testing/) | 1,306 / 1,308 · **99.85%** |
@@ -77,9 +74,16 @@ Lexbench-Headless-Browser 把这个前提变成可以测的东西：每道 task 
 | [Lightpanda](https://github.com/lightpanda-io/browser) | 697 / 1,308 · **53.29%** |
 | [Obscura](https://github.com/h4ckf0r0day/obscura) | 587 / 1,308 · **44.88%** |
 
+</div>
+
 这份对比取同一份 1,928 道任务集的一个子集：剔除面对远程端点失败无法归因的题，剔除对五个引擎一视同仁；剔除不代表这些题在 Kitesurf 提供本地二进制后就一定能通过。子集定义和完整报告见 [`kitesurf-eval` 分支](https://github.com/lexmount/Lexbench-Headless-Browser/blob/kitesurf-eval/README.zh.md)。
 
 </details>
+
+本次 run 的参数：run id `four_engine_full_20260812`，bench tag `2026.08.02-v0_4.1`，seed `official20260709`，k=3，共 23,136 条结果行。一道题三次 attempt 全部通过才算通过。每个引擎只按自己的 attempt 计分（`--score-mode independent`），Chrome 是参照列。完整报告见 [docs](docs/reports/four-engine-report-20260812.md)。
+
+> [!NOTE]
+> 如果你关心 Cloudflare 新发布的 agent-first 云端浏览器 [Kitesurf](https://blog.cloudflare.com/kitesurf/)，它的评测在 [`kitesurf-eval`](https://github.com/lexmount/Lexbench-Headless-Browser/blob/kitesurf-eval/README.zh.md) 分支。Kitesurf 目前只以远程端点形态存在，没有二进制摘要、无法测量资源，五引擎结果在该分支发布。
 
 ## Resource Cost
 
@@ -105,6 +109,8 @@ Lexbench-Headless-Browser 把这个前提变成可以测的东西：每道 task 
 
 13 个 driver 横跨五个语言生态，版本全部固定在 [`harness_pins.json`](harness_pins.json)，`doctor` 在每次 run 前逐一校验：
 
+<div align="center">
+
 | Driver | 生态 | 控制路径 | 版本 pin |
 |:---|:---|:---|:---|
 | [playwright-core](https://github.com/microsoft/playwright) | Node | CDP（框架 API） | 1.61.1 |
@@ -120,6 +126,8 @@ Lexbench-Headless-Browser 把这个前提变成可以测的东西：每道 task 
 | [ferrum](https://github.com/rubycdp/ferrum) | Ruby | CDP（生态 driver） | 0.17.2 |
 | [chrome-devtools-mcp](https://github.com/ChromeDevTools/chrome-devtools-mcp) | Node | MCP → Puppeteer → CDP | 1.6.0 |
 | [agent-browser](https://github.com/vercel-labs/agent-browser) | Node | CLI 会话 → CDP | 0.31.1 |
+
+</div>
 
 任务集由 `manifest.json` 固定：同一个 bench 版本内任务内容冻结，任何改动都必须提升版本号。任务集会随引擎和 driver 生态的演进持续扩充，新增的 subset 和 task 以新的 bench 版本发布。
 
@@ -137,6 +145,8 @@ Lexbench-Headless-Browser 把这个前提变成可以测的东西：每道 task 
 
 ## Documentation
 
+<div align="center">
+
 | 文档 | 回答什么 |
 |:---|:---|
 | [docs/RUNNING.zh.md](docs/RUNNING.zh.md) | 怎么装引擎和 driver，怎么把 bench 跑起来 |
@@ -144,7 +154,11 @@ Lexbench-Headless-Browser 把这个前提变成可以测的东西：每道 task 
 | [docs/RESULTS.zh.md](docs/RESULTS.zh.md) | 结果怎么读：判定边界与适用范围 |
 | [docs/reports/](docs/reports/) | 报告本身，由 run 产物生成 |
 
+</div>
+
 ## Repository Layout
+
+<div align="center">
 
 | 路径 | 内容 |
 |:---|:---|
@@ -157,6 +171,8 @@ Lexbench-Headless-Browser 把这个前提变成可以测的东西：每道 task 
 | [`harness_pins.json`](harness_pins.json) | 各生态的 driver 版本 pin |
 | [`test/`](test/) | 框架单元测试（stdlib + pytest，不需要引擎二进制） |
 | [`docs/`](docs/) | 怎么跑、怎么复现、结果怎么读，以及报告 |
+
+</div>
 
 ## License
 


### PR DESCRIPTION
Final polish round on both READMEs:

- The collapsed five-engine glance moves to directly under the four-engine table, before the run-parameters line, so the wider comparison sits next to the leaderboard.
- The coverage strip drops "5 language ecosystems": the tool names already carry the breadth, and the ecosystems are spelled out in the driver table one click below.
- Every table (five-engine glance, driver table, Documentation, Repository Layout) is wrapped in a centered block, matching the charts and badges.
- The English Kitesurf note drops its evidence-class clause to stay parallel with the trimmed Chinese note.