### PR TITLE
Give the branch README the badge tagline and center its tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,14 @@
   <a href="README.md">English</a> · <a href="README.zh.md">中文</a>
 </p>
 
-<p align="center"><strong>The next user of the headless browser is the agent.</strong></p>
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)"
+            srcset="https://img.shields.io/badge/The%20next%20users%20of%20the%20headless%20browser%20are%20agents.-3D74D9?style=for-the-badge">
+    <img src="https://img.shields.io/badge/The%20next%20users%20of%20the%20headless%20browser%20are%20agents.-2050B3?style=for-the-badge"
+         alt="The next users of the headless browser are agents." />
+  </picture>
+</p>
 
 You are on `kitesurf-eval`, the evaluation lane for [Kitesurf](https://blog.cloudflare.com/kitesurf/), the agent-first cloud browser Cloudflare just launched. The [`main`](https://github.com/lexmount/Lexbench-Headless-Browser) branch carries the full story: the benchmark's motivation, the four-engine leaderboard over locally pinned binaries, and the resource measurements. Kitesurf exists only behind a remote endpoint, with no binary digest and no process tree to measure, so its evidence class differs from a local binary (`formal_score_eligible: false`). This branch adds the fifth column, the machinery that makes a remote engine measurable at all, and reports the comparison on two explicitly defined task subsets. Everything else, the 1,928-task set, the drivers, the graders and the methodology, is identical to `main`.
 
@@ -57,6 +64,8 @@ Median peak process-tree memory per task: Lightpanda 34 MiB, Obscura 39 MiB, Mol
 
 ## Documentation
 
+<div align="center">
+
 | Document | What it answers |
 |:---|:---|
 | [docs/kitesurf-deployment.md](docs/kitesurf-deployment.md) | Deploying the fixtures and running the Kitesurf lane |
@@ -65,6 +74,8 @@ Median peak process-tree memory per task: Lightpanda 34 MiB, Obscura 39 MiB, Mol
 | [docs/REPRODUCE.md](docs/REPRODUCE.md) | Reproducing the published runs and regenerating their reports |
 | [docs/RESULTS.md](docs/RESULTS.md) | Reading the results: scoring boundaries and limits |
 | [docs/reports/](docs/reports/) | The reports themselves, generated from run artifacts |
+
+</div>
 
 ## What this branch adds
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -13,7 +13,14 @@
   <a href="README.md">English</a> · <a href="README.zh.md">中文</a>
 </p>
 
-<p align="center"><strong>无头浏览器的下一个使用者是 Agent。</strong></p>
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)"
+            srcset="https://img.shields.io/badge/%E6%97%A0%E5%A4%B4%E6%B5%8F%E8%A7%88%E5%99%A8%E7%9A%84%E4%B8%8B%E4%B8%80%E4%B8%AA%E4%BD%BF%E7%94%A8%E8%80%85%E6%98%AF%20Agent%E3%80%82-3D74D9?style=for-the-badge">
+    <img src="https://img.shields.io/badge/%E6%97%A0%E5%A4%B4%E6%B5%8F%E8%A7%88%E5%99%A8%E7%9A%84%E4%B8%8B%E4%B8%80%E4%B8%AA%E4%BD%BF%E7%94%A8%E8%80%85%E6%98%AF%20Agent%E3%80%82-2050B3?style=for-the-badge"
+         alt="无头浏览器的下一个使用者是 Agent。" />
+  </picture>
+</p>
 
 你现在在 `kitesurf-eval`，也就是 Cloudflare 新发布的 agent-first 云端浏览器 [Kitesurf](https://blog.cloudflare.com/kitesurf/) 的评测分支。完整的项目介绍与动机在 [`main`](https://github.com/lexmount/Lexbench-Headless-Browser/blob/main/README.zh.md) 分支：这个 benchmark 为什么存在、四个本地固定二进制引擎的排行榜，以及资源测量。Kitesurf 目前只以远程端点的形态存在，没有二进制摘要，也没有可测量的进程树，证据等级与本地二进制不同（`formal_score_eligible: false`）。这个分支加上第五列、让远程引擎变得可测的那套机制，并在两个明确定义的任务子集上发布对比结果。其余一切（1,928 道任务集、driver、grader 和方法）与 `main` 完全一致。
 
@@ -57,6 +64,8 @@
 
 ## Documentation
 
+<div align="center">
+
 | 文档 | 回答什么 |
 |:---|:---|
 | [docs/kitesurf-deployment.zh.md](docs/kitesurf-deployment.zh.md) | 怎么部署 fixture，怎么跑 Kitesurf lane |
@@ -65,6 +74,8 @@
 | [docs/REPRODUCE.zh.md](docs/REPRODUCE.zh.md) | 怎么复现已发布的 run，怎么重新生成报告 |
 | [docs/RESULTS.zh.md](docs/RESULTS.zh.md) | 结果怎么读：判定边界与适用范围 |
 | [docs/reports/](docs/reports/) | 报告本身，由 run 产物生成 |
+
+</div>
 
 ## 这个分支多了什么
 


### PR DESCRIPTION
Syncs the branch README with the header and table styling settled on `main` (#8):

- The plain bold tagline becomes the same deep-blue badge as main (light `#2050B3`, dark `#3D74D9`), in both languages.
- The documentation table joins the results table in a centered block, so every table on the page is centered.