### PR TITLE
Start the harness package at 0.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lexbench-headless-browser-harness",
-  "version": "0.5.0",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lexbench-headless-browser-harness",
-      "version": "0.5.0",
+      "version": "0.1.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@browserbasehq/stagehand": "3.7.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lexbench-headless-browser-harness",
-  "version": "0.5.0",
+  "version": "0.1.0",
   "private": true,
   "license": "Apache-2.0",
   "description": "Pinned framework drivers for Browser Runtime Bench: real Playwright / Puppeteer connect-over-CDP harness. Versions are locked in harness_pins.json; install with `npm ci`.",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lexbench-headless-browser"
-version = "0.5.0"
+version = "0.1.0"
 description = "Agent Browser Bench: a native-capability benchmark for browser runtimes across real automation driver stacks (CDP, WebDriver, and framework clients)"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
The package version was `0.5.0` from the repository's first commit, with no 0.1 through 0.4 behind it and nothing on record for what the 5 meant. Next to a corpus labelled `v0_4`, it read as the next step in that sequence. It never was: `v0_4` counts corpus generations (there are `fixtures/v0_2`, `v0_3`, `v0_4` directories and `v2_`/`v4_` task prefixes to match), while this number counts releases of the harness code.

`0.1.0` is the first public cut of the harness, which is what this is, and it no longer invites the comparison.

`package.json`, `pyproject.toml` and the two root entries of `package-lock.json` move together; dependency versions are untouched and `npm ls --package-lock-only` still reports the lockfile consistent. Nothing reads this value at runtime: `run_manifest.json` records adapter and tree digests rather than a harness version, and `installed_pip_version` looks up driver packages, not this one.

A version field cannot be dropped altogether. PEP 621 requires `version` unless the project declares it dynamic, and removing it from `package.json` while the lockfile still carries one makes `npm ci` complain.