### PR TITLE
Unify the versioning scheme

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ A smoke round finishes in minutes, with per-task pass/fail in `runs/<run-id>/res
 
 ## Benchmark Composition
 
-Current bench version `2026.08.17-v0_4.2`: 1,928 tasks in 18 subsets, on two layers. The published run above remains pinned to `2026.08.02-v0_4.1`; the current version changes task descriptions and non-executable metadata, not task membership, drivers, graders, fixtures, or capability assignments.
+Current dataset version `0.4.2`: 1,928 tasks in 18 subsets, on two layers. The published run above remains pinned to `0.4.1` (recorded in its manifest as `2026.08.02-v0_4.1`, the dated label used before the version scheme was unified). The difference is a PATCH: task descriptions and non-executable metadata, not task membership, drivers, graders, fixtures, or capability assignments. How the dataset and harness versions are bumped: [Versioning](docs/RESULTS.md#versioning).
 
 **L1 measures protocol and driver compatibility (1,740 tasks) across two paths:**
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -102,7 +102,7 @@ Lexbench-Headless-Browser 把"这个前提"变成了可以测量、可以复现�
 
 ## 测试集构成
 
-当前 bench 版本 `2026.08.17-v0_4.2`：共 1,928 道 task、18 个子集，分两层（L1 / L2）。上文发布的 run 仍固定在 `2026.08.02-v0_4.1`——本次版本只是调整了 task 描述和不参与执行的元数据，没有改变任务集、driver、grader、fixture 或 capability 归属。
+当前数据集版本 `0.4.2`：共 1,928 道 task、18 个子集，分两层（L1 / L2）。上文发布的 run 仍固定在 `0.4.1`（其 manifest 里记为 `2026.08.02-v0_4.1`，那是版本号统一之前的带日期旧标签）。两者的差异是一个 PATCH：只调整了 task 描述和不参与执行的元数据，没有改变任务集、driver、grader、fixture 或 capability 归属。数据集版本与 harness 版本各自怎么递增，见 [版本号](docs/RESULTS.zh.md#版本号)。
 
 **L1：测协议与 driver 兼容性，共 1,740 道，走两条路径**
 

--- a/docs/REPRODUCE.md
+++ b/docs/REPRODUCE.md
@@ -12,7 +12,7 @@ Every number in the reports traces back to one of three runs. This page records 
 | `resource_baseline_20260812` | Resource round A | `l1.raw_cdp` + `l2.web_platform`, 557 tasks | 5 | 1 | off |
 | `resource_engine_20260812` | Resource round B | same 557 tasks | 5 | 1 | on |
 
-Run parameters: bench `2026.08.02-v0_4.1`, seed `official20260709`, `--score-mode independent --chrome-baseline best_effort`, engines `chrome,moli,lightpanda,obscura`. Engine pins (version and sha256) are listed in each report's provenance table and enforced by `doctor`; where to get each binary ([Moli](https://github.com/lexmount/moli), [Chrome for Testing](https://googlechromelabs.github.io/chrome-for-testing/), [Lightpanda](https://github.com/lightpanda-io/browser), [Obscura](https://github.com/h4ckf0r0day/obscura)) and where to place it are covered in [RUNNING.md](RUNNING.md). The commands below are taken verbatim from each run's recorded `argv` in its `run_manifest.json`.
+Run parameters: bench `2026.08.02-v0_4.1` — dataset `0.4.1` under the current scheme, see [Versioning](RESULTS.md#versioning) — seed `official20260709`, `--score-mode independent --chrome-baseline best_effort`, engines `chrome,moli,lightpanda,obscura`. Engine pins (version and sha256) are listed in each report's provenance table and enforced by `doctor`; where to get each binary ([Moli](https://github.com/lexmount/moli), [Chrome for Testing](https://googlechromelabs.github.io/chrome-for-testing/), [Lightpanda](https://github.com/lightpanda-io/browser), [Obscura](https://github.com/h4ckf0r0day/obscura)) and where to place it are covered in [RUNNING.md](RUNNING.md). The commands below are taken verbatim from each run's recorded `argv` in its `run_manifest.json`.
 
 The functional run:
 

--- a/docs/REPRODUCE.zh.md
+++ b/docs/REPRODUCE.zh.md
@@ -12,7 +12,7 @@
 | `resource_baseline_20260812` | 资源 A 轮 | `l1.raw_cdp` + `l2.web_platform`，557 道 | 5 | 1 | 关 |
 | `resource_engine_20260812` | 资源 B 轮 | 同一批 557 道 | 5 | 1 | 开 |
 
-三次 run 的共同参数：bench 版本 `2026.08.02-v0_4.1`、seed `official20260709`、`--score-mode independent --chrome-baseline best_effort`、引擎 `chrome,moli,lightpanda,obscura`。每个引擎的 pin（版本与 sha256）列在各报告最后的溯源表里，由 `doctor` 强制校验；二进制的获取位置——[Moli](https://github.com/lexmount/moli)、[Chrome for Testing](https://googlechromelabs.github.io/chrome-for-testing/)、[Lightpanda](https://github.com/lightpanda-io/browser)、[Obscura](https://github.com/h4ckf0r0day/obscura)——与放置路径见 [RUNNING.zh.md](RUNNING.zh.md)。下面的命令逐字取自各 run 的 `run_manifest.json` 里记录的 `argv`（实际启动参数）。
+三次 run 的共同参数：bench 版本 `2026.08.02-v0_4.1`（按当前方案即数据集 `0.4.1`，见[版本号](RESULTS.zh.md#版本号)）、seed `official20260709`、`--score-mode independent --chrome-baseline best_effort`、引擎 `chrome,moli,lightpanda,obscura`。每个引擎的 pin（版本与 sha256）列在各报告最后的溯源表里，由 `doctor` 强制校验；二进制的获取位置——[Moli](https://github.com/lexmount/moli)、[Chrome for Testing](https://googlechromelabs.github.io/chrome-for-testing/)、[Lightpanda](https://github.com/lightpanda-io/browser)、[Obscura](https://github.com/h4ckf0r0day/obscura)——与放置路径见 [RUNNING.zh.md](RUNNING.zh.md)。下面的命令逐字取自各 run 的 `run_manifest.json` 里记录的 `argv`（实际启动参数）。
 
 **功能 run：**
 

--- a/docs/RESULTS.md
+++ b/docs/RESULTS.md
@@ -72,6 +72,24 @@ The L2 mechanisms are the ones production pages lean on, with third-party usage 
 - Client-side storage is silent infrastructure. Chrome's last published counters had IndexedDB reads on 19.3% and writes on 16.6% of page loads ([bucket 3023](https://chromestatus.com/metrics/feature/timeline/popularity/3023), [bucket 3024](https://chromestatus.com/metrics/feature/timeline/popularity/3024)); Firestore's web offline persistence is IndexedDB ([docs](https://firebase.google.com/docs/firestore/manage-data/enable-offline)). The agent-relevant failure mode motivated these tasks: an engine that degrades a missing storage API gracefully renders the page anyway with empty data, and the agent confidently reports a wrong answer instead of an error. Only a storage-semantics task exposes that.
 - Driver interaction primitives consume layout and computed style directly. Playwright's actionability rules require a non-empty bounding box, computed visibility and hit-target checks before every click or fill ([playwright.dev/docs/actionability](https://playwright.dev/docs/actionability)). An engine with incomplete style or layout does not lose one task; it loses the framework's waiting and clicking substrate. Lightpanda's own documentation states its Web API coverage is incomplete ([lightpanda.io/docs](https://lightpanda.io/docs/)), consistent with where its L2 misses cluster.
 
+## Versioning
+
+Two numbers, two questions.
+
+**Dataset — `bench_version` in `manifest.json`, currently `0.4.2`.** What was measured: which tasks exist, and which drivers, graders, fixtures and capability assignments they run against. It exists to answer whether two runs are comparable, so it is bumped by what a change would do to a comparison:
+
+| Bump | What changed | Effect on published numbers |
+|:---|:---|:---|
+| MAJOR | Task membership, graders, fixtures, or capability assignments | Not comparable; the denominator moved |
+| MINOR | Additive — new tasks or subsets, existing ones untouched | Existing subsets stay comparable |
+| PATCH | Task descriptions and other non-executable metadata | Fully comparable |
+
+The fixture tree belongs to this axis: editing a fixture changes results, so it is a MAJOR bump. Every run records `runner.fixtures.tree_sha256`, which is what makes that claim checkable rather than declarative.
+
+**Harness — `runner/version.py`, currently `0.1.0`.** The code that runs the dataset, mirrored in `pyproject.toml` and `package.json`. Bumping it does not change what is being measured, so runs stay comparable across it. Runs record it as `harness_version`.
+
+Runs predating this scheme carry a dated label instead: the three published runs record `2026.08.02-v0_4.1`, which is `0.4.1` here, and its difference from `0.4.2` is PATCH — descriptions only, fully comparable. Neither number is what makes a run reproducible. `run_manifest.json` pins the manifest, fixture tree, runner source and capability map by sha256, and those digests are the identity a re-run is checked against; the versions are the labels that let a reader skip the check.
+
 ## Boundaries
 
 - Screenshot, PDF and raster output are outside the current measurement scope. This is a deferred boundary, not a permanent verdict: it predates candidate engines growing paint pipelines and is tracked for re-evaluation. Nothing here measures pixel correctness.

--- a/docs/RESULTS.zh.md
+++ b/docs/RESULTS.zh.md
@@ -77,6 +77,24 @@ L2 选的机制是生产页面真实依赖的，并配了第三方使用数据�
 - **客户端存储是沉默的基础设施。** Chrome 最后一批公开计数显示：19.3% 的页面加载执行了 IndexedDB 读、16.6% 执行了写（[bucket 3023](https://chromestatus.com/metrics/feature/timeline/popularity/3023)、[bucket 3024](https://chromestatus.com/metrics/feature/timeline/popularity/3024)）；Firestore 的 web 离线持久化底层就是 IndexedDB（[文档](https://firebase.google.com/docs/firestore/manage-data/enable-offline)）。促成这批题的正是 Agent 场景特有的失败方式：引擎对缺失的存储 API **优雅降级**，页面照常渲染但数据为空，Agent 会自信地给出错误答案而不是报错——只有存储语义题能暴露这一点。
 - **driver 的交互原语直接消费 layout 和 computed style。** Playwright 的 actionability 规则要求每次 click/fill 前有非空 bounding box、computed 可见性和 hit-target 检查（[playwright.dev/docs/actionability](https://playwright.dev/docs/actionability)）。样式或布局不完整的引擎，丢掉的不是某一道题，而是**框架自动等待与点击的底座**。Lightpanda 自己的文档写明其 Web API 覆盖不完整（[lightpanda.io/docs](https://lightpanda.io/docs/)），与它 L2 失误的聚集位置一致。
 
+## 版本号
+
+两个数字，回答两个问题。
+
+**数据集 —— `manifest.json` 里的 `bench_version`，当前 `0.4.2`。** 它标识**测的是什么**：有哪些 task，以及它们跑在哪些 driver、grader、fixture 和 capability 归属上。它存在的意义就是回答"两次 run 能不能比"，因此按"这次改动对可比性做了什么"来递增：
+
+| 递增位 | 改了什么 | 对已发布数字的影响 |
+|:---|:---|:---|
+| MAJOR | 任务集、grader、fixture 或 capability 归属 | 不可比，分母变了 |
+| MINOR | 纯新增——加 task 或子集，原有的不动 | 原有子集仍可比 |
+| PATCH | task 描述及其他不参与执行的元数据 | 完全可比 |
+
+fixture 树属于这条轴：改 fixture 会改结果，所以算 MAJOR。每次 run 都记录 `runner.fixtures.tree_sha256`，这条声明因此是可核对的，而不只是写在文档里。
+
+**Harness —— `runner/version.py`，当前 `0.1.0`。** 跑这个数据集的代码，`pyproject.toml` 与 `package.json` 与之同步。它递增不改变被测对象，因此跨 harness 版本的 run 仍然可比。run 会把它记为 `harness_version`。
+
+这套方案之前的 run 记的是带日期的旧标签：三次已发布的 run 记录为 `2026.08.02-v0_4.1`，在这里就是 `0.4.1`，它与 `0.4.2` 的差异是 PATCH——只改了描述，完全可比。另外，这两个数字都不是可复现性的承重墙：`run_manifest.json` 用 sha256 固定了 manifest、fixture 树、runner 源码树和 capability map，重跑时被核对的是这些摘要；版本号只是让读者可以不做这一步核对的标签。
+
 ## 边界
 
 - **截图、PDF 与光栅输出不在当前测量范围内。** 这是**暂缓**而不是永久结论：这条边界划定于候选引擎普遍还没有 paint 管线的时期，已列入重新评估。这里的一切都不测像素正确性。

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "bench_id": "agent_browser_bench",
-  "bench_version": "2026.08.17-v0_4.2",
+  "bench_version": "0.4.2",
   "default_k_runs": 1,
   "engine_policy": "repo_build_artifacts_pinned_binaries",
   "engines": {
@@ -148,7 +148,6 @@
   "root_dir": "Lexbench-Headless-Browser",
   "site": {
     "base_url": "http://127.0.0.1:{port}",
-    "kind": "self_hosted_fixture",
-    "site_version": "2026.07.10-fixtures"
+    "kind": "self_hosted_fixture"
   }
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lexbench-headless-browser"
-version = "0.1.0"
+dynamic = ["version"]
 description = "Agent Browser Bench: a native-capability benchmark for browser runtimes across real automation driver stacks (CDP, WebDriver, and framework clients)"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -33,6 +33,9 @@ Repository = "https://github.com/lexmount/Lexbench-Headless-Browser"
 # auto-discovery refuses the layout and `pip install -e .` fails.
 [tool.setuptools]
 packages = ["runner"]
+
+[tool.setuptools.dynamic]
+version = { attr = "runner.version.HARNESS_VERSION" }
 
 [tool.pytest.ini_options]
 testpaths = ["test"]

--- a/runner/__init__.py
+++ b/runner/__init__.py
@@ -1,1 +1,5 @@
 """Agent Browser Bench runner package."""
+
+from .version import HARNESS_VERSION as __version__
+
+__all__ = ["__version__"]

--- a/runner/run.py
+++ b/runner/run.py
@@ -35,6 +35,7 @@ if __package__:
     from runner import resources as resource_metrics
     from runner import semantics as semantic_model
     from runner.launch_profiles import DEFAULT_LAUNCH_PROFILE, LAUNCH_PROFILES
+    from runner.version import HARNESS_VERSION
 else:
     # Keep the historical direct-script entry point (`python3 runner/run.py`)
     # working as well as the preferred module form (`python3 -m runner.run`).
@@ -42,6 +43,7 @@ else:
     import resources as resource_metrics
     import semantics as semantic_model
     from launch_profiles import DEFAULT_LAUNCH_PROFILE, LAUNCH_PROFILES
+    from version import HARNESS_VERSION
 
 
 BENCH_ROOT = pathlib.Path(__file__).resolve().parents[1]
@@ -1957,6 +1959,16 @@ def validate_manifest(
     for field in ["bench_id", "bench_version", "root_dir", "fallback_allowed", "default_k_runs", "site", "engines", "layers"]:
         if field not in suite:
             errors.append(f"{manifest_path}: missing required field `{field}`")
+    # The dataset version is the one number that tells a reader whether two runs
+    # are comparable, so its shape is enforced rather than left to convention.
+    # MAJOR: task membership, graders, fixtures or capability assignments moved.
+    # MINOR: additive, existing subsets unchanged. PATCH: descriptions and other
+    # non-executable metadata. See docs/RESULTS.md.
+    bench_version = suite.get("bench_version")
+    if "bench_version" in suite and not re.fullmatch(r"\d+\.\d+\.\d+", str(bench_version)):
+        errors.append(
+            f"{manifest_path}: bench_version must be MAJOR.MINOR.PATCH, got `{bench_version}`"
+        )
     if suite.get("fallback_allowed") is not False:
         errors.append(f"{manifest_path}: fallback_allowed must be false for native runs")
     if not isinstance(suite.get("layers"), list):
@@ -2230,6 +2242,7 @@ def run_manifest_payload(
         "argv": [sanitize_launch_part(part) for part in sys.argv],
         "bench_id": suite.get("bench_id"),
         "bench_version": suite.get("bench_version"),
+        "harness_version": HARNESS_VERSION,
         "bench_manifest": {
             "path": rel_to_repo(manifest_path),
             "sha256": sha256_file(manifest_path),
@@ -2293,9 +2306,11 @@ def run_manifest_payload(
             ),
             "affects_functional_score": False,
         },
+        # The fixture tree is part of what `bench_version` identifies; the run
+        # records its digest under `runner.fixtures`, so there is no second
+        # version label for it here.
         "site": {
             "base_url": fixture_base_url,
-            "site_version": suite.get("site", {}).get("site_version"),
         },
         "runner": {
             "python": sys.version.split()[0],
@@ -6727,7 +6742,7 @@ def build_run_digest_lines(
         "Agent Browser Bench run",
         "-----------------------",
         f"run_id      {run_id}",
-        f"bench       {suite.get('bench_id')} @ {suite.get('bench_version')}",
+        f"bench       {suite.get('bench_id')} @ {suite.get('bench_version')}; harness {HARNESS_VERSION}",
         f"manifest    {rel_to_repo(manifest_path)} sha12={sha256_file(manifest_path)[:12]}",
         f"dataset     selected_tasks={selected_count}{enabled_suffix}; layers {format_count_map(count_tasks_by(tasks, 'layer'))}",
         f"subsets     {format_count_map(count_tasks_by(tasks, 'subset_id'))}",
@@ -7952,6 +7967,7 @@ def summarize_results(run_manifest: dict[str, Any], rows: list[dict[str, Any]]) 
         "run_id": run_manifest.get("run_id"),
         "bench_id": run_manifest.get("bench_id") or "agent_browser_bench",
         "bench_version": run_manifest.get("bench_version") or "unknown",
+        "harness_version": run_manifest.get("harness_version") or "unknown",
         "score_eligible": bool(run_manifest.get("score_eligible")),
         "layers": layers,
         "evaluation_axes": evaluation_axes,

--- a/runner/version.py
+++ b/runner/version.py
@@ -1,0 +1,14 @@
+"""Harness version: the version of the code that runs the benchmark.
+
+Deliberately separate from `manifest.json`'s `bench_version`, which identifies
+the dataset — which tasks exist, which graders and fixtures they run against.
+The two move for different reasons: a harness fix does not change what is being
+measured, and a dataset change does not require new code. Collapsing them would
+cost the reader the one question a version number here is meant to answer: are
+two runs comparable? See docs/RESULTS.md.
+
+Single source of truth: `pyproject.toml` reads it from here, and a unit test
+holds `package.json` to the same value.
+"""
+
+HARNESS_VERSION = "0.1.0"

--- a/test/TESTING.md
+++ b/test/TESTING.md
@@ -276,6 +276,7 @@ Lexbench-Headless-Browser/
     _fakes.py                    # FakeCDP (scripted HTTP+WS) / StubProc / task & manifest factories
     _stub_scripts/stub.js        # mode-switched node stub for node_cdp_probe (no real CDP connection)
     test_unit_validate.py        # §2: good+bad for every validate rule
+    test_unit_versioning.py      # dataset (bench_version) and harness version: shapes, single source, run_manifest
     test_unit_gate_score.py      # §5: Chrome baseline priority / 5 score_eligible reasons / should_include_score
     test_unit_checks.py          # §2: all grade_inline kinds / seed determinism / parse_engines / placeholder substitution
     test_fixture_server.py       # §7: static serving / routing / directory-traversal blocking / expected_answer / anti-cheating

--- a/test/_fakes.py
+++ b/test/_fakes.py
@@ -371,11 +371,11 @@ def default_manifest() -> dict[str, Any]:
     """A minimal, valid suite manifest for tmp bench trees."""
     return {
         "bench_id": "unit_bench",
-        "bench_version": "0.0-test",
+        "bench_version": "0.0.0",
         "root_dir": "unit_bench",
         "fallback_allowed": False,
         "default_k_runs": 1,
-        "site": {"kind": "self_hosted_fixture", "site_version": "test"},
+        "site": {"kind": "self_hosted_fixture"},
         "engines": {
             "chrome": {"role": "gold_baseline"},
             "moli": {"role": "native_candidate"},

--- a/test/test_unit_versioning.py
+++ b/test/test_unit_versioning.py
@@ -1,0 +1,78 @@
+"""The two version axes: the dataset (`bench_version`) and the harness.
+
+`bench_version` in manifest.json identifies the dataset — which tasks exist and
+which graders and fixtures they run against. The harness version in
+runner/version.py identifies the code that runs them. They are bumped for
+different reasons, so both shapes are enforced here, and the harness version is
+held to a single source of truth across pyproject.toml and package.json.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+import re
+
+import pytest
+
+from runner import run as runner_run
+from runner.version import HARNESS_VERSION
+
+REPO_ROOT = pathlib.Path(runner_run.REPO_ROOT)
+SEMVER = re.compile(r"\d+\.\d+\.\d+")
+
+
+def read_json(name: str) -> dict:
+    return json.loads((REPO_ROOT / name).read_text(encoding="utf-8"))
+
+
+def test_dataset_version_is_semver():
+    assert SEMVER.fullmatch(read_json("manifest.json")["bench_version"])
+
+
+def test_manifest_carries_no_second_version_label():
+    # The fixture tree is part of what bench_version identifies, and a run
+    # records its digest under runner.fixtures. A separate site_version would
+    # be a second label to forget.
+    assert "site_version" not in read_json("manifest.json")["site"]
+
+
+def test_harness_version_is_semver():
+    assert SEMVER.fullmatch(HARNESS_VERSION)
+
+
+def test_npm_package_agrees_on_the_harness_version():
+    assert read_json("package.json")["version"] == HARNESS_VERSION
+
+
+def test_pyproject_reads_the_harness_version_from_one_place():
+    text = (REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8")
+    assert 'dynamic = ["version"]' in text
+    assert 'attr = "runner.version.HARNESS_VERSION"' in text
+
+
+@pytest.mark.parametrize("bad", ["2026.08.17-v0_4.2", "0.4", "v0.4.2", "0.4.2-rc1", ""])
+def test_validate_rejects_a_non_semver_dataset_version(bench_factory, bad):
+    def mutate(manifest):
+        manifest["bench_version"] = bad
+
+    manifest_path = bench_factory(manifest_mut=mutate)
+    _suite, _tasks, errors = runner_run.validate_manifest(manifest_path)
+    assert any("bench_version must be MAJOR.MINOR.PATCH" in error for error in errors)
+
+
+def test_run_manifest_records_both_axes():
+    manifest_path = REPO_ROOT / "manifest.json"
+    suite, tasks, errors = runner_run.validate_manifest(
+        manifest_path, requested_subsets=["l1.raw_cdp"]
+    )
+    assert errors == []
+    args = argparse.Namespace(
+        chrome_gate="off", score_mode="independent", jobs=1, k=1, seed="unit"
+    )
+    payload = runner_run.run_manifest_payload(
+        args, suite, manifest_path, tasks[:1], ["moli"], "unit_versioning", True, [], None
+    )
+    assert payload["bench_version"] == suite["bench_version"]
+    assert payload["harness_version"] == HARNESS_VERSION
+    assert "site_version" not in payload["site"]

--- a/tools/report_four_engine.py
+++ b/tools/report_four_engine.py
@@ -145,6 +145,10 @@ def build_report(manifest: dict, rows: list[dict], scores: dict) -> str:
     out(f"# Agent Browser Bench Four-Engine Evaluation (L1 + L2)")
     out("")
     header = f"**Run** `{manifest.get('run_id')}` · {run_date} · Bench `{manifest.get('bench_version')}`"
+    # Runs recorded before the harness was versioned carry no harness_version;
+    # their reports keep regenerating byte-identically without one.
+    if manifest.get("harness_version"):
+        header += f" · Harness `{manifest['harness_version']}`"
     out(header)
     out("")
     engine_names = ", ".join(engine_label(manifest, e) for e in engines)


### PR DESCRIPTION
Closes #16.

### The problem

Three version numbers, no stated relationship between them:

| Where | Before | What it means |
|---|---|---|
| `manifest.json` → `bench_version` | `2026.08.17-v0_4.2` | which tasks the benchmark contains |
| `manifest.json` → `site.site_version` | `2026.07.10-fixtures` | the fixtures — but no code ever read it |
| `package.json`, `pyproject.toml` | `0.1.0` | the harness code |

Two of them are dates, one is semver, and the `v0_4.x` part is left over from the private repo.

### What this PR does

Keeps two of them, deletes the third.

**1. The dataset version becomes `0.4.2`** (was `2026.08.17-v0_4.2`).

This number answers one question: if I re-run the benchmark, can I compare my numbers with the published ones? So it is bumped by what the answer becomes:

| Bump | When | Still comparable? |
|---|---|---|
| MAJOR | tasks added or removed, or a grader, fixture or capability assignment changed | No, the denominator moved |
| MINOR | tasks or subsets added, existing ones untouched | Yes, for the existing subsets |
| PATCH | task descriptions and other text that does not run | Yes |

`validate` now rejects anything that is not `MAJOR.MINOR.PATCH`.

Why `0.4.2` and not `1.0.0`: the published runs recorded `2026.08.02-v0_4.1`, which is `0.4.1`. Everything that changed since is task descriptions — a PATCH. Restarting at `1.0.0` would tell a reader the dataset changed and the published numbers no longer apply, which is not true.

**2. The harness version stays `0.1.0`, but now lives in one place.**

`runner/version.py` holds it, `pyproject.toml` reads it from there, and a test keeps `package.json` in sync. Runs record it as `harness_version`, so a report can say which code produced it.

**3. `site_version` is deleted.**

Nothing read it. The fixtures it labelled are part of the dataset: editing a fixture changes results, so that is a MAJOR bump of the dataset version. Every run already records `runner.fixtures.tree_sha256`, which can be checked — unlike a label someone has to remember to update.

### What breaks

1. The old dated `bench_version` is now a hard `validate` error. The three published runs keep their old string; new runs record semver.
2. `run_manifest.json` no longer carries `site.site_version`. It is in the three published run manifests and will be in none of the future ones.

Neither affects reproducibility: a run is identified by the sha256 digests in `run_manifest.json`, not by these labels.

### Checks

- `validate`, `scenarios --check`, `pytest`: 599 passed, 7 skipped (11 new)
- The published four-engine report still regenerates byte-for-byte identical to the committed copy
